### PR TITLE
Save/load token to/from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ test.sh
 .DS_Store
 upload.sh
 
+# Files with environment variables
+env.sh
+env.env

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,5 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+# Project exclude paths
+/.

--- a/.idea/keycloak-api.iml
+++ b/.idea/keycloak-api.iml
@@ -2,9 +2,13 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/kcapi.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (keycloak-api)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.1 (keycloak-api)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/env.env.sample
+++ b/env.env.sample
@@ -1,0 +1,4 @@
+KC_ENDPOINT=https://my-sso.openshiftapps.com/
+KC_USER=admin
+KC_PASSWORD=adminpass
+KC_REALM=ci-test-realm

--- a/env.sh.sample
+++ b/env.sh.sample
@@ -1,0 +1,4 @@
+export KC_ENDPOINT=https://my-sso.openshiftapps.com/
+export KC_USER=admin
+export KC_PASSWORD=adminpass
+export KC_REALM=ci-test-realm

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 # This call to setup() does all the work
 setup(
     name="kcapi",
-    version="1.0.22",
+    version="1.0.25",
     description="A module to automate stuff in Keycloak.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Token can be saved to json file, and later loaded from the file.

File can be any file-like object - so also `sys.stdin` or string (environ variable) wrapped by `io.StringIO` can be used.

Both access and refresh token are included into json. The `token_endpoint` is included too, as it is needed for refresh; same is true for `expires_in` and `start_time`. Complete `well_known` is not included - it is quite large, and I think it is not really needed.

kcapi version jumps from 1.0.22 to 1.0.25 - on pypi is already 1.0.24, seems setup.py was outdated.