### PR TITLE
Support Keycloak with self-signed certificate

### DIFF
--- a/.idea/keycloak-api.iml
+++ b/.idea/keycloak-api.iml
@@ -2,7 +2,10 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/kcapi" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
+      <excludeFolder url="file://$MODULE_DIR$/.idea" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (keycloak-api)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ pip install kcapi
 
 To run the test you would need a Keycloak instance, you can run one locally or in the [cloud]( https://developers.redhat.com/developer-sandbox/get-started) then you just have to follow this steps: 
 
+To start a Keycloak instance in docker container use command like below.
+In this case TLS certificate verification needs to be disabled for testing.
+
+```shell
+# keycloak:15.0.2 is close to RedHat SSO 7.5
+docker run -d -p 8080:80 -p 8433:443 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:15.0.2 -b 0.0.0.0
+```
+
+With Keycloak instance running we can start tests:
+
 ```shell script
 python3.10 -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ export KC_ENDPOINT=https://my-first-sso-me-me-dev.apps.sandbox.x8i5.p1.openshift
 python -m unittest
 ```
 
+## Optionally disable TLS certificate verification
+
+Environment variable `KEYCLOAK_API_CA_BUNDLE` can be used to disable TLS certificate verification.
+`KEYCLOAK_API_CA_BUNDLE` can have 3 different values:
+- unset (default) - TLS verification is enforced
+- empty string - TLS verification is disabled
+- path to file or directory
+  - file contains a CA certificate bundle or,
+  - directory contains individual CA certificate files.
 
 ## API
 

--- a/kcapi/oid.py
+++ b/kcapi/oid.py
@@ -23,7 +23,8 @@ def craft_error_message(resp, url):
 def get_well_known_info(url, realm):
     discovery_url = RestURL(url, ['auth', 'realms', realm, '.well-known', 'openid-configuration'])
 
-    resp = KcSession().get(url=str(discovery_url))
+    with KcSession() as session:
+        resp = session.get(url=str(discovery_url))
 
     if resp.status_code == 200:
         return resp.json()
@@ -85,7 +86,8 @@ class Token:
             "refresh_token": self.refresh_token
         }
 
-        resp = KcSession().post(token_endpoint, data=body)
+        with KcSession() as session:
+            resp = session.post(token_endpoint, data=body)
 
         if resp.status_code != 200:
             craft_error_message(resp, token_endpoint)
@@ -138,7 +140,8 @@ class OpenID:
     def getToken(self):
         url = self.url
         well_known = get_well_known_info(url, self.realm)
-        resp = KcSession().post(well_known['token_endpoint'], data=self.credentials)  #
+        with KcSession() as session:
+            resp = session.post(well_known['token_endpoint'], data=self.credentials)
 
         if resp.status_code == 200:
             payload = resp.json()

--- a/kcapi/oid.py
+++ b/kcapi/oid.py
@@ -1,5 +1,6 @@
-import requests, json, time
+import json, time
 from .rest import RestURL
+from kcsession import KcSession
 
 def craft_error_message(resp, url):
     code = resp.status_code
@@ -22,7 +23,7 @@ def craft_error_message(resp, url):
 def get_well_known_info(url, realm):
     discovery_url = RestURL(url, ['auth', 'realms', realm, '.well-known', 'openid-configuration'])
 
-    resp = requests.get(url=str(discovery_url))
+    resp = KcSession().get(url=str(discovery_url))
 
     if resp.status_code == 200:
         return resp.json()
@@ -84,7 +85,7 @@ class Token:
             "refresh_token": self.refresh_token
         }
 
-        resp = requests.post(token_endpoint, data=body)
+        resp = KcSession().post(token_endpoint, data=body)
 
         if resp.status_code != 200:
             craft_error_message(resp, token_endpoint)
@@ -137,7 +138,7 @@ class OpenID:
     def getToken(self):
         url = self.url
         well_known = get_well_known_info(url, self.realm)
-        resp = requests.post(well_known['token_endpoint'], data=self.credentials)
+        resp = KcSession().post(well_known['token_endpoint'], data=self.credentials)  #
 
         if resp.status_code == 200:
             payload = resp.json()

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -36,30 +36,35 @@ class KeycloakCRUD(object):
     def create(self, payload):
         url = self.targets.url('create')
 
-        ret = KcSession().post(url, data=json.dumps(payload), headers=self.headers())
+        with KcSession() as session:
+            ret = session.post(url, data=json.dumps(payload), headers=self.headers())
         return ResponseHandler(url, method='Post', payload=payload).handleResponse(ret)
 
     def update(self, obj_id=None, payload=None):
         url = self.targets.url('update')
         target = str(self.setIdentifier(obj_id, url))
 
-        ret = KcSession().put(target, data=json.dumps(payload), headers=self.headers())
+        with KcSession() as session:
+            ret = session.put(target, data=json.dumps(payload), headers=self.headers())
         return ResponseHandler(target, method='Put', payload=payload).handleResponse(ret)
 
     def remove(self, _id):
         delete = self.targets.url('delete')
         url = self.setIdentifier(_id, delete)
-        ret = KcSession().delete(url, headers=self.headers())
+        with KcSession() as session:
+            ret = session.delete(url, headers=self.headers())
         return ResponseHandler(url, method='Delete').handleResponse(ret)
         
     def get(self, _id):
         url = self.targets.url('read')
-        ret = KcSession().get(str(self.setIdentifier(_id, url)), headers=self.headers())
+        with KcSession() as session:
+            ret = session.get(str(self.setIdentifier(_id, url)), headers=self.headers())
         return ResponseHandler(url, method='Get').handleResponse(ret)
 
     def findAll(self):
         url = self.targets.url('read')
-        ret = KcSession().get(url, headers=self.headers())
+        with KcSession() as session:
+            ret = session.get(url, headers=self.headers())
         return ResponseHandler(url, method='Get').handleResponse(ret)
 
     def findFirst(self, params):

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -102,7 +102,7 @@ class KeycloakCRUD(object):
 
     def existByKV(self, key, value): 
         ret = self.findFirstByKV(key, value)
-        return ret != False
+        return ret != []
 
     def exist(self, _id):
         return self.get(_id).ok()

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -1,5 +1,6 @@
-import requests, json
+import json
 from .resp import ResponseHandler
+from kcsession import KcSession
 
 class KeycloakCRUD(object):
     @staticmethod
@@ -35,30 +36,30 @@ class KeycloakCRUD(object):
     def create(self, payload):
         url = self.targets.url('create')
 
-        ret = requests.post(url, data=json.dumps(payload), headers=self.headers())
+        ret = KcSession().post(url, data=json.dumps(payload), headers=self.headers())
         return ResponseHandler(url, method='Post', payload=payload).handleResponse(ret)
 
     def update(self, obj_id=None, payload=None):
         url = self.targets.url('update')
         target = str(self.setIdentifier(obj_id, url))
 
-        ret = requests.put(target, data=json.dumps(payload), headers=self.headers())
+        ret = KcSession().put(target, data=json.dumps(payload), headers=self.headers())
         return ResponseHandler(target, method='Put', payload=payload).handleResponse(ret)
 
     def remove(self, _id):
         delete = self.targets.url('delete')
         url = self.setIdentifier(_id, delete)
-        ret = requests.delete(url, headers=self.headers())
+        ret = KcSession().delete(url, headers=self.headers())
         return ResponseHandler(url, method='Delete').handleResponse(ret)
         
     def get(self, _id):
         url = self.targets.url('read')
-        ret = requests.get(str(self.setIdentifier(_id, url)), headers=self.headers())
+        ret = KcSession().get(str(self.setIdentifier(_id, url)), headers=self.headers())
         return ResponseHandler(url, method='Get').handleResponse(ret)
 
     def findAll(self):
         url = self.targets.url('read')
-        ret = requests.get(url, headers=self.headers())
+        ret = KcSession().get(url, headers=self.headers())
         return ResponseHandler(url, method='Get').handleResponse(ret)
 
     def findFirst(self, params):

--- a/kcapi/rest/groups.py
+++ b/kcapi/rest/groups.py
@@ -58,7 +58,8 @@ class GroupAndRolesMappingBuilder():
         remove_target = self.rolesMappings.targets.url('delete')
         headers = self.rolesMappings.headers()
 
-        ret = KcSession().delete(remove_target, data=json.dumps(populatedListOfRoles), headers=headers )
+        with KcSession() as session:
+            ret = session.delete(remove_target, data=json.dumps(populatedListOfRoles), headers=headers )
         return ResponseHandler(remove_target).handleResponse(ret)
 
 class Groups(KeycloakCRUD): 

--- a/kcapi/rest/groups.py
+++ b/kcapi/rest/groups.py
@@ -1,5 +1,5 @@
 import json
-import requests
+from kcsession import KcSession
 
 from .crud import KeycloakCRUD
 from .resp import ResponseHandler
@@ -58,7 +58,7 @@ class GroupAndRolesMappingBuilder():
         remove_target = self.rolesMappings.targets.url('delete')
         headers = self.rolesMappings.headers()
 
-        ret = requests.delete(remove_target, data=json.dumps(populatedListOfRoles), headers=headers )
+        ret = KcSession().delete(remove_target, data=json.dumps(populatedListOfRoles), headers=headers )
         return ResponseHandler(remove_target).handleResponse(ret)
 
 class Groups(KeycloakCRUD): 

--- a/kcsession.py
+++ b/kcsession.py
@@ -9,8 +9,8 @@ class KcSession(requests.Session):
     - disable certificate verification (KEYCLOAK_API_CA_BUNDLE=""), or,
     - use alternative CA bundle (KEYCLOAK_API_CA_BUNDLE="/path/to/file-or-dir").
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
+        super().__init__()
         # similar to REQUESTS_CA_BUNDLE
         if "KEYCLOAK_API_CA_BUNDLE" in os.environ:
             if os.environ["KEYCLOAK_API_CA_BUNDLE"]:

--- a/kcsession.py
+++ b/kcsession.py
@@ -1,0 +1,19 @@
+import os
+import requests
+
+
+class KcSession(requests.Session):
+    """
+    Small wrapper around requests.Session.
+    KEYCLOAK_API_CA_BUNDLE environ variable can be used to:
+    - disable certificate verification (KEYCLOAK_API_CA_BUNDLE=""), or,
+    - use alternative CA bundle (KEYCLOAK_API_CA_BUNDLE="/path/to/file-or-dir").
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # similar to REQUESTS_CA_BUNDLE
+        if "KEYCLOAK_API_CA_BUNDLE" in os.environ:
+            if os.environ["KEYCLOAK_API_CA_BUNDLE"]:
+                self.verify = os.environ["KEYCLOAK_API_CA_BUNDLE"]
+            else:
+                self.verify = False

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -117,7 +117,8 @@ class Testing_User_API(unittest.TestCase):
             from kcapi.rest.resp import ResponseHandler
             url = obj.targets.url('create')
             data_file = SlowFile(json.dumps(payload), [10]*10)
-            ret = KcSession().post(url, data=data_file, headers=obj.headers())
+            with KcSession() as session:
+                ret = session.post(url, data=data_file, headers=obj.headers())
             return ResponseHandler(url, method='Post', payload=payload).handleResponse(ret)
 
         state = users_create(users, self.USER_DATA)

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -117,7 +117,7 @@ class Testing_User_API(unittest.TestCase):
             from kcapi.rest.resp import ResponseHandler
             url = obj.targets.url('create')
             data_file = SlowFile(json.dumps(payload), [10]*10)
-            ret = requests.post(url, data=data_file, headers=obj.headers())
+            ret = KcSession().post(url, data=data_file, headers=obj.headers())
             return ResponseHandler(url, method='Post', payload=payload).handleResponse(ret)
 
         state = users_create(users, self.USER_DATA)


### PR DESCRIPTION
I just want to run tests with KC running in local container, and this means a self-signed certificate.
Certificate verification is configured similar as for requests library - just instead of REQUESTS_CA_BUNDLE environ variable we use KEYCLOAK_API_CA_BUNDLE. It can be empty to disable verification, or it can contain path to file (or directory) with CA bundle (or individual CA certificates).

This should also enable using a local container to implement testing in github actions.

One bug was found, and was fixed. Test `KEYCLOAK_API_CA_BUNDLE="" python -m unittest test.test_crud.Testing_User_API` was failing.