### PR TITLE
Allow searching for object with missing key

### DIFF
--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -74,8 +74,9 @@ class KeycloakCRUD(object):
     def findFirstByKV(self, key, value):
         rows = self.findAll().verify().resp().json()
 
-        for row in rows: 
-            if row[key].lower() == value.lower():
+        for row in rows:
+            # Some components do not have Name attribute.
+            if key in row and row[key].lower() == value.lower():
                 return row
 
         return []


### PR DESCRIPTION
Some components do not have Name attribute.
See also https://github.com/justinc1/keycloak-fetch-bot/issues/19

We do not want code to crash, instead nothing is returned. 