### PR TITLE
Fix composite roles

### DIFF
--- a/.idea/keycloak-api.iml
+++ b/.idea/keycloak-api.iml
@@ -8,7 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (keycloak-api)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (keycloak-api)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (keycloak-api) (2)" project-jdk-type="Python SDK" />
 </project>

--- a/kcapi/rest/clients.py
+++ b/kcapi/rest/clients.py
@@ -29,7 +29,7 @@ class Composites():
 
         # It just adds few extra resource to the url: /id/composites
         self.post = lambda payload: KeycloakCRUD.derive(kc, ['roles-by-id' , self.id, 'composites']).create(payload)
-        self.remove = lambda payload: KeycloakCRUD.derive(kc, ['roles-by-id', self.id, 'composites']).remove(payload)
+        self.remove = lambda payload: KeycloakCRUD.derive(kc, ['roles-by-id', self.id, 'composites']).remove(_id=None, payload=payload)
 
         # It just adds few extra resource to the url: /id/composites/realm
         self.get = lambda: KeycloakCRUD.derive(kc,  ['roles-by-id' , self.id, 'composites', 'realm']).findAll()
@@ -50,7 +50,9 @@ class Composites():
         if not role:
             raise ("Error the role " + roleName + " not found!")
 
-        return self.remove(role['id'])
+        # Whole role representation needed in DELETE payload
+        # See https://www.keycloak.org/docs-api/20.0.1/rest-api/index.html#_roles_by_id_resource
+        return self.remove([role])
 
     def findAll(self):
         return self.get()

--- a/kcapi/rest/clients.py
+++ b/kcapi/rest/clients.py
@@ -1,10 +1,21 @@
+from copy import copy
+
 from .crud import KeycloakCRUD
 
 
 class Role():
     def __init__(self, kc, role):
         self.value = role
-        self.kc = kc
+
+        # Note: Composites() kc param must be top-level API URL
+        kc_top_level = copy(kc)
+        for rest_method in kc_top_level.targets.targets:
+            custom_url = kc_top_level.targets.targets[rest_method].copy()
+            assert custom_url.resources[-1] == 'clients'
+            custom_url.removeLast()
+            kc_top_level.targets.targets[rest_method] = custom_url
+
+        self.kc = kc_top_level
 
     def composite(self):
         return Composites(self.kc, self.value['id'])
@@ -12,6 +23,7 @@ class Role():
 
 class Composites():
     def __init__(self, kc, roleID):
+        # Note: kc must be top-level API URL
         self.kc = kc
         self.id = roleID
 
@@ -39,6 +51,7 @@ class Composites():
             raise ("Error the role " + roleName + " not found!")
 
         return self.remove(role['id'])
+
     def findAll(self):
         return self.get()
 

--- a/kcapi/rest/clients.py
+++ b/kcapi/rest/clients.py
@@ -21,20 +21,21 @@ class Role():
         return Composites(self.kc, self.value['id'])
 
 
-class Composites():
+class Composites:
     def __init__(self, kc, roleID):
         # Note: kc must be top-level API URL
         self.kc = kc
         self.id = roleID
 
         # It just adds few extra resource to the url: /id/composites
-        self.post = lambda payload: KeycloakCRUD.derive(kc, ['roles-by-id' , self.id, 'composites']).create(payload)
-        self.remove = lambda payload: KeycloakCRUD.derive(kc, ['roles-by-id', self.id, 'composites']).remove(_id=None, payload=payload)
-
+        roles_by_id_api = KeycloakCRUD.get_child(kc, None, "roles-by-id")
+        self.post = lambda payload: KeycloakCRUD.get_child(roles_by_id_api, self.id, 'composites').create(payload)
+        self.remove = lambda payload: KeycloakCRUD.get_child(roles_by_id_api, self.id, 'composites').remove(_id=None, payload=payload)
         # It just adds few extra resource to the url: /id/composites/realm
-        self.get = lambda: KeycloakCRUD.derive(kc,  ['roles-by-id' , self.id, 'composites', 'realm']).findAll()
-
-        self.get_role_by_name = lambda name='': KeycloakCRUD.derive(kc, ['roles']).findFirstByKV(key='name', value=name)
+        # Hm. This assumes composite client role will contain only realm roles (not other client roles).
+        # Is this always true, does this cover all usecases?
+        self.get = lambda: KeycloakCRUD.get_child(roles_by_id_api, self.id, 'composites/realm').findAll()
+        self.get_role_by_name = lambda name='': KeycloakCRUD.get_child(kc, None, 'roles').findFirstByKV(key='name', value=name)
 
     def link(self, roleName):
         role = self.get_role_by_name(roleName)

--- a/kcapi/rest/clients.py
+++ b/kcapi/rest/clients.py
@@ -10,7 +10,6 @@ class Role():
         return Composites(self.kc, self.value['id'])
 
 
-
 class Composites():
     def __init__(self, kc, roleID):
         self.kc = kc
@@ -51,15 +50,17 @@ def hack_rest_roles_remove_endpoint(that, kc):
 
     return kc
 
+
 def new_child(kc, query, child_resource):
     client_id = kc.findFirst(query)['id']
-    return KeycloakCRUD.get_child(kc, [client_id, child_resource])
+    return KeycloakCRUD.get_child(kc, client_id, child_resource)
+
 
 class Clients(KeycloakCRUD):
 
     def secrets(self, client_query):
         obj = super().findFirst(client_query)
-        child = KeycloakCRUD.get_child(self, [obj['id'], 'client-secret'])
+        child = KeycloakCRUD.get_child(self, obj['id'], 'client-secret')
         return child
 
     def get_roles(self, client_query):
@@ -68,7 +69,7 @@ class Clients(KeycloakCRUD):
 
     def roles(self, client_query):
         client_id = super().findFirst(client_query)['id']
-        child = KeycloakCRUD.get_child(self, [client_id, 'roles'])
+        child = KeycloakCRUD.get_child(self, client_id, 'roles')
         client_role_api = hack_rest_roles_remove_endpoint(self, child)
 
         return client_role_api

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -14,22 +14,6 @@ class KeycloakCRUD(object):
 
         return kc
 
-    # derive() is similar to get_child, but it allows to
-    # get API to grand-child (you can add 2 or more components to URL).
-    def derive(that, resources):
-        assert isinstance(resources, list)
-        for rr in resources:
-            assert isinstance(rr, str)
-
-        kc = KeycloakCRUD()
-        kc.token = that.token
-        kc.targets = that.targets.copy()
-
-        kc.targets.addResources(resources)
-
-        return kc
-
-
     def __init__(self): 
         self.targets = None
         self.token = None

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -65,12 +65,12 @@ class KeycloakCRUD(object):
             ret = session.put(target, data=json.dumps(payload), headers=self.headers())
         return ResponseHandler(target, method='Put', payload=payload).handleResponse(ret)
 
-    def remove(self, _id):
+    def remove(self, _id, payload=None):
         delete = self.targets.url('delete')
         url = self.setIdentifier(_id, delete)
         with KcSession() as session:
-            ret = session.delete(url, headers=self.headers())
-        return ResponseHandler(url, method='Delete').handleResponse(ret)
+            ret = session.delete(url, data=json.dumps(payload), headers=self.headers())
+        return ResponseHandler(url, method='Delete', payload=payload).handleResponse(ret)
         
     def get(self, _id):
         url = self.targets.url('read')

--- a/kcapi/rest/crud.py
+++ b/kcapi/rest/crud.py
@@ -14,6 +14,22 @@ class KeycloakCRUD(object):
 
         return kc
 
+    # derive() is similar to get_child, but it allows to
+    # get API to grand-child (you can add 2 or more components to URL).
+    def derive(that, resources):
+        assert isinstance(resources, list)
+        for rr in resources:
+            assert isinstance(rr, str)
+
+        kc = KeycloakCRUD()
+        kc.token = that.token
+        kc.targets = that.targets.copy()
+
+        kc.targets.addResources(resources)
+
+        return kc
+
+
     def __init__(self): 
         self.targets = None
         self.token = None

--- a/test/test_clients.py
+++ b/test/test_clients.py
@@ -22,7 +22,6 @@ class TestClients(unittest.TestCase):
         state = clients.create({"enabled":True,"attributes":{},"secret":secret_passphrase ,"redirectUris":[],"clientId":"44","protocol":"openid-connect", "publicClient": False}).isOk()
         self.assertTrue(state, "A private client should be created")
 
-
         #client_secrets = clients.secrets({'key': 'clientId', 'value':"44"})
         #remote_passphrase = client_secrets.all()
 
@@ -30,9 +29,6 @@ class TestClients(unittest.TestCase):
         #self.assertTrue(client_secrets_creation_state, "A secret passphrase should be assigned.")
         #remote_passphrase = client_secrets.all()
         #self.assertTrue(len(remote_passphrase)>0, "We expect to obtain a new passphrase.")
-
-
-
 
     def test_client_roles(self):
         client_payload = load_sample('./test/payloads/client.json')
@@ -92,9 +88,6 @@ class TestClients(unittest.TestCase):
         self.assertTrue(result, 'The server should return ok.')
 
         self.assertEqual(client_roles_api.findFirstByKV('name', client_role_name), [], 'It should return the posted client')
-
-
-
 
     @classmethod
     def setUpClass(self):


### PR DESCRIPTION
Crud.derive - this method never existed.

Wrong URLs were called. If we have client at URL `/realms/{realm}/clients/{client}`, then sub-roles for a known role are at `/realms/{realm}/roles-by-id/{role}/composites`.

To unlink sub-role from composite role, DELETE method needs to be called with array of role representations (not just with role uuid).
