### PR TITLE
Small fix for loading execution flow

### DIFF
--- a/kcapi/ie/auth_flows.py
+++ b/kcapi/ie/auth_flows.py
@@ -1,16 +1,76 @@
-def create_flow(flow):
-    alias = flow['displayName']
-    pid = None if not 'provider' in flow else flow['providerId']
-    provider = 'registration-page-flow' if not pid else pid
-    flow_type = 'basic-flow' if not pid else 'form-flow'
+from copy import copy
 
+
+# def create_flow(flow):
+#     alias = flow['displayName']
+#     pid = None if not 'provider' in flow else flow['providerId']
+#     provider = 'registration-page-flow' if not pid else pid
+#     flow_type = 'basic-flow' if not pid else 'form-flow'
+#
+#     # WARN: The value description is not well validated in Keycloak, it can return 500.
+#     return {
+#         "alias": alias,
+#         "type": flow_type,
+#         "description": "empty",
+#         "provider": provider,
+#     }
+
+# replacement for create_flow()
+def create_child_flow_data(flow):
+    """
+    :param flow: What was stored in json file.
+    :return: What needs to be POST-ed to server to create a flow.
+    Look at kcfetcher inject_data.py for POST/.create() examples.
+    """
+    assert 'authenticationFlow' in flow and flow['authenticationFlow'] is True
+    assert 'topLevel' not in flow
+
+    # https://172.17.0.3:8443/auth/admin/realms/ci0-realm/authentication/flows
+    # description is returned, they are flows, and they are top level flows.
+    # topLevel==true
+    # Payload to create those top-level flows is NOT computed here.
+    #
+    # https://172.17.0.3:8443/auth/admin/realms/ci0-realm/authentication/flows/ci0-auth-flow-generic/executions
+    # They can be child flows or child executions
+    # Payload to create child executions is NOT computed here.
+    # Here is computed only payload for child flows.
+    #
+    # API reponse for child flow
+    # - there is no alias, but it has displayName.
+    # - no topLevel attribute
+    # - has level in index attribute
+    #
+    # So: for child flows, on POST/.create() we send some alias.
+    # On GET/.get() alias attribute is not returned is not returned, but value of alias is in displayName.
+    assert "alias" not in flow
+    alias = flow['displayName']
+
+    # In .json (API GET response) we have "providerId", to server we send (API POST) "provider".
+    pid = flow.get('providerId')
+
+    # Child flows are created with "provider"=="registration-page-form"
+    # Child executions have providerId stored in json.
+    # provider = pid or 'registration-page-flow'  # orig concept
+    assert pid != 'registration-page-flow'  # just want to know if 'registration-page-flow' is ever used.
+    provider = pid or 'registration-page-form'  # this will work on ci0-auth-flow-generic-exec-3-generic-alias case
+
+    # flow_type = 'basic-flow' if not pid else 'form-flow'  # orig code
+    if pid:
+        flow_type = 'form-flow'
+    else:
+        flow_type = 'basic-flow'
+
+    assert "description" not in flow
+    # Real description is not even stored by kcfethcer
+    # Seems real description is not even returned by API - is not observable, likely we can just ignore it
     # WARN: The value description is not well validated in Keycloak, it can return 500.
-    return {
+    data = {
         "alias": alias,
         "type": flow_type,
-        "description": "empty",
+        "description": "empty-description",
         "provider": provider,
     }
+    return data
 
 
 def get_executions(execution):
@@ -19,6 +79,8 @@ def get_executions(execution):
 
 
 def is_auth_flow(body):
+    if 'authenticationFlow' in body:
+        assert body['authenticationFlow'] is True
     return 'authenticationFlow' in body
 
 
@@ -79,6 +141,10 @@ class AuthenticationFlowsImporter():
         self.flowAPI = authentication_api
 
     def update(self, root_node, flows):
+        # flows - child flows (from executors.json) belonging to root_node top-level flow.
+        # TODO setup configj for flows/executions that were configured.
+        assert root_node["topLevel"] is True
+
         flow_api = self.flowAPI.flows(root_node)
         executions_api = self.flowAPI.executions(root_node)
 
@@ -94,10 +160,15 @@ class AuthenticationFlowsImporter():
                     if has_change:
                         flow_api.update(None, updated_flow).isOk()
                 else:
-                    executions_api.update(None, flow).isOk()
+                    flow_min = copy(flow)
+                    flow_min.pop("authenticationConfigData", {})
+                    executions_api.update(None, flow_min).isOk()
         else:
+            # Create top-level flow.
+            # TODO - remove/create only if change is needed.
             self.remove(root_node)
             self.flowAPI.create(root_node).isOk()
+            # Now create child flows.
             self.publish(root_node, flows)
 
     def remove(self, root_node):
@@ -118,7 +189,7 @@ class AuthenticationFlowsImporter():
             parent = nodes[current_level]
 
             if is_auth_flow(flow):
-                authentication_flow = create_flow(flow)
+                authentication_flow = create_child_flow_data(flow)
                 nodes[current_level + 1] = authentication_flow
                 self.flowAPI.flows(parent).create(authentication_flow).isOk()
             else:
@@ -128,3 +199,50 @@ class AuthenticationFlowsImporter():
             if not consistent(root_flow, flow):
                 raise Exception(
                     'There is an inconsistency problem: Changes are not taking place in the server, latency problems ?.')
+
+
+"""
+debugging
+what is created by kcfetcher inject_data.py
+
+1
+execution
+authenticationFlow missing
+"providerId": "direct-grant-validate-username"
+
+2
+execution
+authenticationFlow missing
+"displayName": "Conditional OTP Form",
+"providerId": "auth-conditional-otp-form",
+"alias": "ci0-auth-flow-generic-exec-20-alias",
+    alias was set when config was added
+
+3
+flow, "type": "basic-flow",
+"authenticationFlow": true,
+"displayName": "ci0-auth-flow-generic-exec-3-generic-alias"
+    POST - alias was stored into displayName
+providerId missing
+
+4
+flow, "type": "basic-flow", child of n3
+"authenticationFlow": true,
+"displayName": "ci0-auth-flow-generic-exec-3-1-flow-alias"
+providerId missing
+
+5
+flow,  "type": "form-flow",
+"authenticationFlow": true,
+"displayName": "ci0-auth-flow-generic-exec-4-flow-alias"
+"providerId": "registration-page-form",
+
+6
+execution, child od 4
+authenticationFlow missing
+"alias": "ci0-auth-flow-generic-exec-6-alias"
+    alias was set when config was added
+"displayName": "Recaptcha",
+"providerId": "registration-recaptcha-action",
+
+"""

--- a/test/test_flows_executors.py
+++ b/test/test_flows_executors.py
@@ -219,7 +219,11 @@ class TestingAuthenticationFlowsAPI(KcBaseTestCase):
         publisher = AuthenticationFlowsImporter(self.authenticationFlow)
 
         clients_flow = {
-            "alias": "clients"
+            "alias": "clients",
+            "builtIn": True,
+            "description": "Base authentication for clients",
+            "providerId": "client-flow",
+            "topLevel": True,
         }
 
         executors = load_sample('./test/payloads/executors/executor_1.json')
@@ -231,7 +235,11 @@ class TestingAuthenticationFlowsAPI(KcBaseTestCase):
         self.assertEqual(execs[3]['requirement'], 'REQUIRED')
 
         reset_credentials_flow = {
-            "alias": "reset credentials"
+            "alias": "reset credentials",
+            "builtIn": True,
+            "description": "Reset credentials for a user if they forgot their password or something",
+            "providerId": "basic-flow",
+            "topLevel": True,
         }
 
         reset_credentials_flow_payload = load_sample('./test/payloads/executors/executor_2.json')
@@ -244,7 +252,11 @@ class TestingAuthenticationFlowsAPI(KcBaseTestCase):
         publisher = AuthenticationFlowsImporter(self.authenticationFlow)
 
         clients_flow = {
-            "alias": "registration"
+            "alias": "registration",
+            "builtIn": True,
+            "description": "registration flow",
+            "providerId": "basic-flow",
+            "topLevel": True,
         }
 
         executors = load_sample('./test/payloads/executors/executor_3.json')


### PR DESCRIPTION
Looking at what UI sends to server, child flow of a top-level flow is created with `provider = 'registration-page-form'`, not ''registration-page-flow''.

"authenticationConfigData" is injected by kcfetcher - kcfetcher replaces "authenticationConfig" uuid with content of corresponding object. We need to drop `authenticationConfigData` before POST-ing to server.