### PR TITLE
Work with full representation also for realm roles

### DIFF
--- a/kcapi/rest/clients.py
+++ b/kcapi/rest/clients.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from .crud import KeycloakCRUD
+from .roles import BaseRoleCRUD
 
 
 class Role():
@@ -23,21 +24,8 @@ class Role():
         return Composites(self.kc, self.value['id'])
 
 
-class ClientRoleCRUD(KeycloakCRUD):
-    _rest_params_read = {"briefRepresentation": False}
-
-    """
-    For RH SSO 7.4 (KC 9.0), role with attributes cannot be created.
-    We need to first create role, then update it to add attributes.
-
-    This will not be needed any more in RH SSO 7.5.
-    """
-    def create(self, payload):
-        ret = super().create(payload)
-        if "attributes" in payload:
-            role = self.findFirstByKV("name", payload["name"])
-            self.update(role["id"], payload).isOk()
-        return ret
+class ClientRoleCRUD(BaseRoleCRUD):
+    pass
 
 
 class Composites:

--- a/kcapi/rest/roles.py
+++ b/kcapi/rest/roles.py
@@ -1,4 +1,29 @@
 from .targets import Targets
+from .crud import KeycloakCRUD
+
+
+class BaseRoleCRUD(KeycloakCRUD):
+    _rest_params_read = {"briefRepresentation": False}
+
+    """
+    For RH SSO 7.4 (KC 9.0), role with attributes cannot be created.
+    We need to first create role, then update it to add attributes.
+
+    This will not be needed any more in RH SSO 7.5.
+    """
+    def create(self, payload):
+        # "composites" are setup via separated API
+        # payload.pop("composites", None)
+
+        ret = super().create(payload)
+        if "attributes" in payload:
+            role = self.findFirstByKV("name", payload["name"])
+            self.update(role["id"], payload).isOk()
+        return ret
+
+
+class RealmRoleCRUD(BaseRoleCRUD):
+    pass
 
 
 # The Keycloak guys decided to use another resource DELETE /roles-by-id, instead of sticking to DELETE /roles.

--- a/kcapi/sso.py
+++ b/kcapi/sso.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from .rest.crud import KeycloakCRUD
 from .rest.targets import Targets
 from .rest.groups import Groups
-from .rest.roles import RolesURLBuilder
+from .rest.roles import RealmRoleCRUD, RolesURLBuilder
 from .rest.users import Users
 from .rest.realms import Realms, RealmURLBuilder
 from .rest.url import RestURL
@@ -19,7 +19,8 @@ KCResourceTypes = {
     "groups": Groups,
     "realms": Realms,
     "authentication": AuthenticationFlows,
-    "clients": Clients
+    "clients": Clients,
+    "roles": RealmRoleCRUD,
 }
 
 URLBuilders = {

--- a/test/test_roles_api.py
+++ b/test/test_roles_api.py
@@ -13,14 +13,29 @@ class Testing_Roles_And_Groups_API(KcBaseTestCase):
     vcr_enabled = False
   
     def testing_roles_creation(self):
-        role = {"name": "magic"}
-        roles = self.kc.build("roles", self.realm)
-        state = roles.create(role).isOk() 
+        role_doc = {"name": "magic"}
+        roles_api = self.kc.build("roles", self.realm)
+        state = roles_api.create(role_doc).isOk()
         self.assertTrue(state)
 
-        ret = roles.findFirstByKV('name', 'magic')
+        ret = roles_api.findFirstByKV('name', 'magic')
 
         self.assertTrue(ret, "We should get the created role back.")
+
+    def testing_roles_creation_with_attributes(self):
+        role_doc = {
+            "name": "magic",
+            "attributes": {
+                "magic-key0": ["magic-value0"],
+            },
+        }
+        roles_api = self.kc.build("roles", self.realm)
+        state = roles_api.create(role_doc).isOk()
+        self.assertTrue(state)
+
+        role = roles_api.findFirstByKV('name', 'magic')
+
+        self.assertEqual(role_doc["attributes"], role["attributes"])
 
 
     def testing_update_roles_creation(self):


### PR DESCRIPTION
"composites" are not removed from role body anymore. It seems this hack is not needed.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>